### PR TITLE
Fix show quote on all screens

### DIFF
--- a/lib/screens/homePage.dart
+++ b/lib/screens/homePage.dart
@@ -196,6 +196,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
               rnd = new Random();
               int r = 0 + rnd.nextInt(_colors.length - 0);
               clr = _colors[r];
+              bloc.fetchAllMovies();
             });
           },
           controller: pageViewController,


### PR DESCRIPTION
Call `bloc.fetchAllMovies(); `in `onPageChanged:` property of PageView.