### PR TITLE
Fix #62 - Import Error in homePage.dart

### DIFF
--- a/lib/screens/homePage.dart
+++ b/lib/screens/homePage.dart
@@ -3,7 +3,7 @@ import 'dart:core';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/material.dart';
 import 'package:in_time/utils/activity_model.dart';
-import 'package:in_time/screens/enterTimeTable.dart';
+import 'package:in_time/screens/enterTimetable.dart';
 import 'package:flutter/widgets.dart';
 
 //drawer


### PR DESCRIPTION
Fixed Import Error in [homePage.dart](https://github.com/nityanandagohain/in-time/blob/master/lib/screens/homePage.dart) for [enterTimetable.dart](https://github.com/nityanandagohain/in-time/blob/master/lib/screens/enterTimetable.dart)

- Fixes #62 